### PR TITLE
added missing required parameters and use HEAD in `git blame`

### DIFF
--- a/plugin/github-comment.vim
+++ b/plugin/github-comment.vim
@@ -58,6 +58,7 @@ function! s:CommentOnGitHub(auth, repo, commit_sha, path, diff_position, comment
   let request_uri = 'https://api.github.com/repos/'.a:repo.'/commits/'.a:commit_sha.'/comments'
 
   let response = webapi#http#post(request_uri, webapi#json#encode({
+                  \  "sha" : a:commit_sha,
                   \  "path" : a:path,
                   \  "position" : a:diff_position,
                   \  "body" : a:comment
@@ -84,7 +85,7 @@ function! s:CommitShaForCurrentLine()
   let linenumber = line('.')
   let path = expand('%:p')
 
-  let cmd = 'git blame -L'.linenumber.','.linenumber.' --porcelain '.path
+  let cmd = 'git blame HEAD -L'.linenumber.','.linenumber.' --porcelain '.path
   let blame_text = system(cmd)
 
   return matchstr(blame_text, '\w\+')
@@ -130,6 +131,7 @@ function! s:Authorize(password)
   let auth = printf("basic %s", webapi#base64#b64encode(g:github_user.":".a:password))
   let response = webapi#http#post('https://api.github.com/authorizations', webapi#json#encode({
                   \  "scopes"        : ["repo"],
+                  \  "note"          : "vim-github-comment Authorization",
                   \}), {
                   \  "Content-Type"  : "application/json",
                   \  "Authorization" : auth,


### PR DESCRIPTION
Two bugs:
- Github API interface has been changed in V3, added missing parameters
  - note in `/Authorizations`
  - sha in commit api
- git blame with no giving any revision will perform 000000000000000000 as author not committed yet if the commit didn't exist in current branch.
