### PR TITLE
Add webapi plugin detection

### DIFF
--- a/plugin/github-comment.vim
+++ b/plugin/github-comment.vim
@@ -21,6 +21,14 @@ if !executable('curl')
   finish
 endif
 
+" webapi uses autoload to define its functions, so they don't exist until they
+" are called.
+silent! call webapi#json#decode('{}')
+if !exists('*webapi#json#decode')
+  echohl ErrorMsg | echomsg "github-comment requires webapi (https://github.com/mattn/webapi-vim)" | echohl None
+  finish
+endif
+
 com! -nargs=+ GHComment call GHComment(<q-args>)
 
 function! GHComment(body)


### PR DESCRIPTION
As explained in the readme, webapi-vim[1](https://github.com/mattn/webapi-vim) is a dependency of
vim-github-comment. To make this obvious for new users, I added some
code to detect if the plugin is available and if it is not, display a
helpful error message.

Since webapi-vim only uses autoload to define its functions, they don't
actually exist until they are called the first time. Therefore, we need
to call one of the functions before checking if it exists. I decided to
go with `webapi#json#decode` since it is already being used by
vim-github-comment.

Fixes #5.
