### PR TITLE
Teach git to ignore /doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
This keeps the repo clean when using pathogen and vim, which is
particularly nice for folks who use git to manage their dot files or who
load up vim plugins as git submodules.
