### PR TITLE
Remove newline from the repository name

### DIFF
--- a/plugin/github-comment.vim
+++ b/plugin/github-comment.vim
@@ -94,6 +94,7 @@ function! s:GitHubRepository()
   let name = split(remote, 'git://github\.com/')[0]
   let name = split(name, 'git@github\.com:')[0]
   let name = split(name, '\.git')[0]
+  let name = substitute(name, '\n\+$', '', '')
 
   return name
 endfunction


### PR DESCRIPTION
Hi,
I had a problem with this plugin - after some debugging it turned out that (at least on my computer), the repo string put into url was not `myuser/myrepo` but `myuser/myrepo\n` (with newline in the end). That caused URL to be like

```
https://api.github.com/repos/swistak35/dotfiles
/commits/some_commit_sha/comments
```

Which caused request to fail.

I'm not sure why is this that it's different on my computer (and I don't really have time to dig into this), but it may probably make this plugin to work for some users - at least it is working for me now.

Feel free to merge, or not, I'm using my fork until then :)

Thanks for this plugin!
